### PR TITLE
Move array from ArrayList to a generic in chocolatey.ps1

### DIFF
--- a/Tasks/chocolatey/chocolatey.ps1
+++ b/Tasks/chocolatey/chocolatey.ps1
@@ -19,7 +19,8 @@ try {
   $chocolateyVersion = & $chocoExe --version
   Write-Output "Running Chocolatey Version: $chocolateyVersion"
 
-  $chocolateyArguments = New-Object System.Collections.ArrayList
+  #Array list is deprecated, switch to a Generic and avoid the costly New-Object call
+  $chocolateyArguments = [System.Collections.Generic.List]::New()
 
   [bool]$debug = Get-VstsInput -Name 'debug' -AsBool -Default $false
   [bool]$verbose = Get-VstsInput -Name 'verbose' -AsBool -Default $false


### PR DESCRIPTION
ArrayLists are expensive in that they produce index output when adding/remove items from them. .Net now includes Generic.List, which can be strongly typed and produce no output on Add/remove operations.

Also removed the New-Object call, as invoking the New() method is faster than calling a cmdlet.

## Expected Behavior

This should run a bit quieter now, and is future proof with non-deprecated classes.


